### PR TITLE
Remove gt4py.next from swm_cartesian

### DIFF
--- a/swm_python/swm_cartesian.py
+++ b/swm_python/swm_cartesian.py
@@ -1,27 +1,17 @@
 import numpy as np
-import numpy as np
-import gt4py.next as gtx
 import gt4py.cartesian.gtscript as gtscript
 import gt4py.storage as gts
+from gt4py.storage.cartesian import utils as gts_utils
 from time import perf_counter
-# import cupy
-# import gt4py
 import initial_conditions
 import utils
 import config
 
-I = gtx.Dimension("I")
-J = gtx.Dimension("J")
-K = gtx.Dimension("K", kind = gtx.DimensionKind.VERTICAL)
-
 dtype = np.float64
 
 cartesian_backend = config.backend
-allocator = gtx.gtfn_cpu
-if cartesian_backend in ("gt:gpu", "cuda", "dace:gpu"):
-    allocator = gtx.gtfn_gpu
 
-print(f"Using {cartesian_backend} backend with {allocator.__name__} allocator.")
+print(f"Using {cartesian_backend} backend.")
 
 @gtscript.stencil(backend=cartesian_backend)
 def calc_cucvzh(u: gtscript.Field[dtype],
@@ -102,8 +92,6 @@ def main():
     dt25 = 0.
     dt3 = 0.
 
-    M_LEN = config.M_LEN
-    N_LEN = config.N_LEN
     M = config.M
     N = config.N
     
@@ -112,50 +100,20 @@ def main():
     _v = _v[:,:,np.newaxis]
     _p = _p[:,:,np.newaxis]
 
-    domain = gtx.domain({I:M+1, J:N+1, K:1})
-
-    # if cartesian_backend in ("gpu","gt:cpu_ifirst","cuda", "dace:gpu"):
-    if cartesian_backend in ("cuda", "dace:gpu"):
-        h_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        z_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        cu_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        cv_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        pnew_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        unew_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        vnew_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        uold_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        vold_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        pold_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        u_gt = gtx.as_field(domain,_u,allocator=allocator)
-        v_gt = gtx.as_field(domain,_v,allocator=allocator)
-        p_gt = gtx.as_field(domain,_p,allocator=allocator)
-    else:
-        shape = (M+1,N+1,1)
-        h_gt  = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        z_gt  = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        cu_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        cv_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        pnew_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        unew_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        vnew_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        uold_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        vold_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        pold_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
-        u_gt    = gts.from_array(_u,dtype=dtype,backend=cartesian_backend)
-        v_gt    = gts.from_array(_v,dtype=dtype,backend=cartesian_backend)
-        p_gt    = gts.from_array(_p,dtype=dtype,backend=cartesian_backend)
-        #
-        #  Create different fields.  These fields are:
-        #      (1) Much slower than the regular fields 
-        #      (2) they support the asnumpy() method needed for validation
-        #
-        utmp_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        vtmp_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        ptmp_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        cutmp_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        cvtmp_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        htmp_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
-        ztmp_gt = gtx.empty(domain,dtype=dtype,allocator=allocator)
+    shape = (M+1,N+1,1)
+    h_gt  = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    z_gt  = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    cu_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    cv_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    pnew_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    unew_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    vnew_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    uold_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    vold_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    pold_gt = gts.empty(dtype=dtype,backend=cartesian_backend,shape=shape)
+    u_gt    = gts.from_array(_u,dtype=dtype,backend=cartesian_backend)
+    v_gt    = gts.from_array(_v,dtype=dtype,backend=cartesian_backend)
+    p_gt    = gts.from_array(_p,dtype=dtype,backend=cartesian_backend)
 
     # Save initial conditions
     uold_gt[...] = u_gt[...]
@@ -170,15 +128,10 @@ def main():
         print(" grid spacing in the y direction: ", config.dy)
         print(" time step: ", config.dt)
         print(" time filter coefficient: ", config.alpha)
-        #
-        # asnumpy() method is not working with from_array allocator
-        #
-        ptmp_gt[...] = p_gt[...]
-        utmp_gt[...] = u_gt[...]
-        vtmp_gt[...] = v_gt[...]
-        print(" Initial p:\n", ptmp_gt.asnumpy()[:,:,0].diagonal()[:-1])
-        print(" Initial u:\n", utmp_gt.asnumpy()[:,:,0].diagonal()[:-1])
-        print(" Initial v:\n", vtmp_gt.asnumpy()[:,:,0].diagonal()[:-1])
+        
+        print(" Initial p:\n", p_gt[:,:,0].diagonal()[:-1])
+        print(" Initial u:\n", u_gt[:,:,0].diagonal()[:-1])
+        print(" Initial v:\n", v_gt[:,:,0].diagonal()[:-1])
 
     t0_start = perf_counter()
     time = 0.0
@@ -195,10 +148,7 @@ def main():
             print(f"cycle number{ncycle} and gt4py type cartesian")
 
         if config.VAL_DEEP and ncycle <= 3:
-            utmp_gt[...]=u_gt[...]
-            vtmp_gt[...]=v_gt[...]
-            ptmp_gt[...]=p_gt[...]
-            utils.validate_uvp(utmp_gt.asnumpy(), vtmp_gt.asnumpy(), ptmp_gt.asnumpy(), M, N, ncycle, 'init')
+            utils.validate_uvp(gts_utils.cpu_copy(u_gt), gts_utils.cpu_copy(v_gt), gts_utils.cpu_copy(p_gt), M, N, ncycle, 'init')
 
         t1_start = perf_counter()
 
@@ -244,11 +194,7 @@ def main():
         dt15 = dt15 + (t15_stop - t15_start)
 
         if config.VAL_DEEP and ncycle <=1:
-            cutmp_gt[...] = cu_gt[...]
-            cvtmp_gt[...] = cv_gt[...]
-            ztmp_gt[...]  = z_gt[...]
-            htmp_gt[...]  = h_gt[...]
-            utils.validate_cucvzh(cutmp_gt.asnumpy(), cvtmp_gt.asnumpy(), ztmp_gt.asnumpy(), htmp_gt.asnumpy(), M, N, ncycle, 't100')
+            utils.validate_cucvzh(gts_utils.cpu_copy(cu_gt), gts_utils.cpu_copy(cv_gt), gts_utils.cpu_copy(z_gt), gts_utils.cpu_copy(h_gt), M, N, ncycle, 't100')
 
         # Calclulate new values of u,v, and p
         tdts8 = tdt / 8.
@@ -308,10 +254,7 @@ def main():
 
         
         if config.VAL_DEEP and ncycle <= 1:
-            utmp_gt[...]=unew_gt[...]
-            vtmp_gt[...]=vnew_gt[...]
-            ptmp_gt[...]=pnew_gt[...]
-            utils.validate_uvp(utmp_gt.asnumpy(), vtmp_gt.asnumpy(), ptmp_gt.asnumpy(), M, N, ncycle, 't200')
+            utils.validate_uvp(gts_utils.cpu_copy(unew_gt), gts_utils.cpu_copy(vnew_gt), gts_utils.cpu_copy(pnew_gt), M, N, ncycle, 't200')
 
         time = time + config.dt
 
@@ -333,23 +276,17 @@ def main():
             v_gt[...] = vnew_gt[...]
             p_gt[...] = pnew_gt[...]
 
-        if((config.VIS == True) & (ncycle%config.VIS_DT==0)):
-            utmp_gt[...]=u_gt[...]
-            vtmp_gt[...]=v_gt[...]
-            ptmp_gt[...]=p_gt[...]
-            utils.live_plot3(utmp_gt.asnumpy(), vtmp_gt.asnumpy(), ptmp_gt.asnumpy(), "ncycle: " + str(ncycle))
+        if((config.VIS) & (ncycle%config.VIS_DT==0)):
+            utils.live_plot3(gts_utils.cpu_copy(u_gt), gts_utils.cpu_copy(v_gt), gts_utils.cpu_copy(p_gt), "ncycle: " + str(ncycle))
 
     t0_stop = perf_counter()
     dt0 = dt0 + (t0_stop - t0_start)
     # Print initial conditions
     if config.L_OUT:
-        utmp_gt[...]=u_gt[...]
-        vtmp_gt[...]=v_gt[...]
-        ptmp_gt[...]=p_gt[...]
         print("cycle number ", config.ITMAX)
-        print(" diagonal elements of p:\n", ptmp_gt.asnumpy()[:,:,0].diagonal()[:-1])
-        print(" diagonal elements of u:\n", utmp_gt.asnumpy()[:,:,0].diagonal()[:-1])
-        print(" diagonal elements of v:\n", vtmp_gt.asnumpy()[:,:,0].diagonal()[:-1])
+        print(" diagonal elements of p:\n", p_gt[:,:,0].diagonal()[:-1])
+        print(" diagonal elements of u:\n", u_gt[:,:,0].diagonal()[:-1])
+        print(" diagonal elements of v:\n", v_gt[:,:,0].diagonal()[:-1])
     print("total: ",dt0)
     print("t100: ",dt1)
     print("t150: ",dt15)
@@ -358,10 +295,7 @@ def main():
     print("t300: ",dt3)
 
     if config.VAL:
-        utmp_gt[...]=u_gt[...]
-        vtmp_gt[...]=v_gt[...]
-        ptmp_gt[...]=p_gt[...]
-        utils.final_validation(utmp_gt.asnumpy(), vtmp_gt.asnumpy(), ptmp_gt.asnumpy(), ITMAX=config.ITMAX, M=M, N=N)
+        utils.final_validation(gts_utils.cpu_copy(u_gt), gts_utils.cpu_copy(v_gt), gts_utils.cpu_copy(p_gt), ITMAX=config.ITMAX, M=M, N=N)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is a PR into @johnmauff's PR, removing usage of `gt4py.next`. Conversion to numpy is via `storage.cartesian.utils.cpu_copy()`.