### PR TITLE
Add ACC directives to Fortran

### DIFF
--- a/swm_fortran/Makefile
+++ b/swm_fortran/Makefile
@@ -20,6 +20,9 @@ all: swm_fortran swm_fortran_driver
 nvfortran:
 	make FC=nvfortran FFLAGS="-r8 -acc=gpu" swm_fortran swm_fortran_driver
 
+nvfortran_noacc:
+	make FC=nvfortran FFLAGS="-r8 -noacc" swm_fortran swm_fortran_driver
+
 swm_fortran: swm_fortran.F90
 	$(FC) $(FFLAGS) -o $@ swm_fortran.F90
 

--- a/swm_fortran/Makefile
+++ b/swm_fortran/Makefile
@@ -17,6 +17,9 @@ LDLIBS = -lm
 # Default target
 all: swm_fortran swm_fortran_driver
 
+nvfortran:
+	make FC=nvfortran FFLAGS="-r8" swm_fortran_driver
+
 swm_fortran: swm_fortran.F90
 	$(FC) $(FFLAGS) -o $@ swm_fortran.F90
 

--- a/swm_fortran/Makefile
+++ b/swm_fortran/Makefile
@@ -18,7 +18,7 @@ LDLIBS = -lm
 all: swm_fortran swm_fortran_driver
 
 nvfortran:
-	make FC=nvfortran FFLAGS="-r8 -acc=gpu" swm_fortran_driver
+	make FC=nvfortran FFLAGS="-r8 -acc=gpu" swm_fortran swm_fortran_driver
 
 swm_fortran: swm_fortran.F90
 	$(FC) $(FFLAGS) -o $@ swm_fortran.F90

--- a/swm_fortran/Makefile
+++ b/swm_fortran/Makefile
@@ -18,7 +18,7 @@ LDLIBS = -lm
 all: swm_fortran swm_fortran_driver
 
 nvfortran:
-	make FC=nvfortran FFLAGS="-r8" swm_fortran_driver
+	make FC=nvfortran FFLAGS="-r8 -acc=gpu" swm_fortran_driver
 
 swm_fortran: swm_fortran.F90
 	$(FC) $(FFLAGS) -o $@ swm_fortran.F90
@@ -37,4 +37,4 @@ swm_fortran_amrex_kernels.o: swm_fortran_amrex_kernels.F90
 	$(FC) $(FFLAGS) -c $@ swm_fortran_amrex_kernels.F90
 
 clean:
-	rm -f swm_fortran swm_fortran_driver swm_fortran_amrex_driver *.o
+	rm -f swm_fortran swm_fortran_driver swm_fortran_amrex_driver *.o *.mod

--- a/swm_fortran/swm_fortran_driver.F90
+++ b/swm_fortran/swm_fortran_driver.F90
@@ -80,7 +80,7 @@ Program SWM_Fortran_Driver
   pcf = pi * pi * a * a / (el * el)
 
   ! Initial values of the stream function and p
-  !$acc enter data copyin(a,di,dj,pcf,psi,p)
+  !$acc enter data copyin(a,di,dj,pcf,psi,p,dx,dy,u,v,uold,vold,pold)
   !$acc parallel loop collapse(2) present(a,di,dj,pcf)
   do j=0,N_LEN-1
     do i=0,M_LEN-1
@@ -90,7 +90,6 @@ Program SWM_Fortran_Driver
   end do
 
   ! Initialize velocities
-  !$acc enter data copyin(dx,dy,u,v)
   !$acc parallel loop collapse(2) present(psi,dx,dy)
   do j=1,N
     do i=1,M
@@ -115,7 +114,6 @@ Program SWM_Fortran_Driver
   u(1,N_LEN) = u(M_LEN,1)
   v(M_LEN,1) = v(1,N_LEN)
 
-  !$acc enter data copyin(uold,vold,pold)
   !$acc parallel loop collapse(2) present(u,v,p)
   do j=1,N_LEN
     do i=1,M_LEN

--- a/swm_fortran/swm_fortran_kernels.F90
+++ b/swm_fortran/swm_fortran_kernels.F90
@@ -12,7 +12,6 @@ contains
 
     integer :: i,j
 
-    !$acc enter data copyin(p,u,v,fsdx,fsdy,cu,cv,h,z)
     !$acc parallel loop collapse(2) present(p,u,v,fsdx,fsdy)
     do j=1,size(cu,2)-1
       do i=1,size(cu,1)-1
@@ -24,7 +23,6 @@ contains
                                   v(i,j+1) * v(i,j+1) + v(i,j) * v(i,j))
       end do
     end do
-    !$acc exit data copyout(cu,cv,z,h)
 
   end subroutine UpdateIntermediateVariablesKernel
 
@@ -36,7 +34,6 @@ contains
 
     integer :: i,j
 
-    !$acc enter data copyin(tdtsdx,tdtsdy,tdts8,cu,cv,z,h,pold,uold,vold,pnew,unew,vnew)
     !$acc parallel loop collapse(2) present(tdtsdx,tdtsdy,tdts8,cu,cv,z,h,pold,uold,vold)
     do j=1,size(unew,2)-1
       do i=1,size(unew,1)-1
@@ -49,7 +46,6 @@ contains
         pnew(i,j) = pold(i,j) - tdtsdx * (cu(i+1,j) - cu(i,j)) - tdtsdy * (cv(i,j+1) - cv(i,j))
       end do
     end do
-    !$acc exit data copyout(unew,vnew,pnew)
 
   end subroutine UpdateNewVariablesKernel
 
@@ -60,16 +56,14 @@ contains
 
     integer :: i,j
 
-    !$acc enter data copyin(alpha,pold,uold,vold,p,u,v,pnew,unew,vnew)
     !$acc parallel loop collapse(2) present(alpha,p,u,v,pnew,unew,vnew)
-    do j=1,size(uold,2)-1
-      do i=1,size(uold,1)-1
+    do j=1,size(uold,2)
+      do i=1,size(uold,1)
         uold(i,j) = u(i,j) + alpha*(unew(i,j) - 2. * u(i,j) + uold(i,j))
         vold(i,j) = v(i,j) + alpha*(vnew(i,j) - 2. * v(i,j) + vold(i,j))
         pold(i,j) = p(i,j) + alpha*(pnew(i,j) - 2. * p(i,j) + pold(i,j))
       end do
     end do
-    !$acc exit data copyout(uold,vold,pold)
 
   end subroutine UpdateOldVariablesKernel
 

--- a/swm_fortran/swm_fortran_kernels.F90
+++ b/swm_fortran/swm_fortran_kernels.F90
@@ -12,6 +12,8 @@ contains
 
     integer :: i,j
 
+    !$acc enter data copyin(p,u,v,fsdx,fsdy,cu,cv,h,z)
+    !$acc parallel loop collapse(2) present(p,u,v,fsdx,fsdy)
     do j=1,size(cu,2)-1
       do i=1,size(cu,1)-1
         cu(i+1,j) = 0.5 * (p(i+1,j) + p(i,j)) * u(i+1,j)
@@ -22,6 +24,8 @@ contains
                                   v(i,j+1) * v(i,j+1) + v(i,j) * v(i,j))
       end do
     end do
+    !$acc exit data copyout(cu,cv,z,h)
+
   end subroutine UpdateIntermediateVariablesKernel
 
   subroutine UpdateNewVariablesKernel(tdtsdx,tdtsdy,tdts8,pold,uold,vold,cu,cv,h,z,pnew,unew,vnew)
@@ -32,6 +36,8 @@ contains
 
     integer :: i,j
 
+    !$acc enter data copyin(tdtsdx,tdtsdy,tdts8,cu,cv,z,h,pold,uold,vold,pnew,unew,vnew)
+    !$acc parallel loop collapse(2) present(tdtsdx,tdtsdy,tdts8,cu,cv,z,h,pold,uold,vold)
     do j=1,size(unew,2)-1
       do i=1,size(unew,1)-1
         unew(i+1,j) = uold(i+1,j) + &
@@ -43,6 +49,8 @@ contains
         pnew(i,j) = pold(i,j) - tdtsdx * (cu(i+1,j) - cu(i,j)) - tdtsdy * (cv(i,j+1) - cv(i,j))
       end do
     end do
+    !$acc exit data copyout(unew,vnew,pnew)
+
   end subroutine UpdateNewVariablesKernel
 
   subroutine UpdateOldVariablesKernel(alpha,pnew,unew,vnew,p,u,v,pold,uold,vold)
@@ -52,6 +60,8 @@ contains
 
     integer :: i,j
 
+    !$acc enter data copyin(alpha,pold,uold,vold,p,u,v,pnew,unew,vnew)
+    !$acc parallel loop collapse(2) present(alpha,p,u,v,pnew,unew,vnew)
     do j=1,size(uold,2)-1
       do i=1,size(uold,1)-1
         uold(i,j) = u(i,j) + alpha*(unew(i,j) - 2. * u(i,j) + uold(i,j))
@@ -59,6 +69,7 @@ contains
         pold(i,j) = p(i,j) + alpha*(pnew(i,j) - 2. * p(i,j) + pold(i,j))
       end do
     end do
+    !$acc exit data copyout(uold,vold,pold)
 
   end subroutine UpdateOldVariablesKernel
 


### PR DESCRIPTION
This only updates `swm_fortran_kernels.F90` (and adds a mechanism for building with `nvfortran` instead of `gfortran`)